### PR TITLE
WIP: Math support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "better-sqlite3": "^11.7.0"
+        "better-sqlite3": "^11.7.0",
+        "markdown-it-math": "^4.1.1"
       },
       "devDependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+        "@benrbray/prosemirror-math": "^1.0.0",
         "@nytimes/react-prosemirror": "^1.0.0",
         "@sentry/electron": "^5.8.0",
         "@types/better-sqlite3": "^7.6.12",
@@ -666,6 +668,24 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@benrbray/prosemirror-math": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@benrbray/prosemirror-math/-/prosemirror-math-1.0.0.tgz",
+      "integrity": "sha512-5fPeOKP6SJJ3usXhhf6vnLXGJnfPHPzv0OdsOJlGkCdZvNfCuC6f8fZqgpmnP8vxDKjB8fvSVSmAHTMsaiXc6w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "katex": "^0.16.10",
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-history": "^1.4.0",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-transform": "^1.8.0",
+        "prosemirror-view": "^1.33.4"
+      }
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -5042,6 +5062,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ascii2mathml": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ascii2mathml/-/ascii2mathml-0.6.2.tgz",
+      "integrity": "sha512-tkPONh2Y7ZpuGQw6AiRnExX/CSYf5C2T/rF+UMJq5n0Us7+QjL8VY5ZE16xo9wcXhdqPkl/F7lzEzU9HX0YKng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "ascii2mathml": "bin/index.js"
       }
     },
     "node_modules/assert-plus": {
@@ -11416,6 +11449,35 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.18",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.18.tgz",
+      "integrity": "sha512-LRuk0rPdXrecAFwQucYjMiIs0JFefk6N1q/04mlw14aVIVgxq1FO0MA9RiIIGVaKOB5GIP5GH4aBBNraZERmaQ==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11876,6 +11938,15 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-math": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-math/-/markdown-it-math-4.1.1.tgz",
+      "integrity": "sha512-LQ0hREgMgN4tNcy2PGyw1XypjmKJjc+ZzATMuDIVD/Bagr5SGL198uHleVdiFDrNdXpqVmL4N1KD1GYyftMakQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "ascii2mathml": "^0.6.2"
       }
     },
     "node_modules/matcher": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+    "@benrbray/prosemirror-math": "^1.0.0",
     "@nytimes/react-prosemirror": "^1.0.0",
     "@sentry/electron": "^5.8.0",
     "@types/better-sqlite3": "^7.6.12",
@@ -126,6 +127,7 @@
     "webpack-dev-server": "^5.2.0"
   },
   "dependencies": {
-    "better-sqlite3": "^11.7.0"
+    "better-sqlite3": "^11.7.0",
+    "markdown-it-math": "^4.1.1"
   }
 }

--- a/src/skrift-electron/renderer/components/NoteEditor/index.tsx
+++ b/src/skrift-electron/renderer/components/NoteEditor/index.tsx
@@ -1,13 +1,19 @@
 import "prosemirror-view/style/prosemirror.css";
+import "@benrbray/prosemirror-math/dist/prosemirror-math.css";
+import "katex/dist/katex.min.css";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { NoteID, NoteWithLinks } from "../../../../skrift/note";
-import { OpenCardMode } from "../../interfaces/state";
 import { ProseMirror, react, useEditorEffect } from "@nytimes/react-prosemirror";
+
+import { mathPlugin, mathBackspaceCmd, insertMathCmd, mathSerializer } from "@benrbray/prosemirror-math";
+
 import { keymap } from "prosemirror-keymap";
 import { buildKeymap } from "./keymap";
 import { history } from "prosemirror-history";
 import { EditorView } from "prosemirror-view";
+
+import { NoteID, NoteWithLinks } from "../../../../skrift/note";
+import { OpenCardMode } from "../../interfaces/state";
 import { markdownParser, schema } from "../../../../skrift-markdown/parser";
 import { EditorState } from "prosemirror-state";
 import { markdownSerializer } from "../../../../skrift-markdown/serializer";
@@ -45,6 +51,7 @@ export const NoteEditor: React.FC<Props> = ({
   const plugins = useMemo(
     () => [
       history(),
+      mathPlugin,
       keymap(buildKeymap(schema)),
       buildInputRules(schema),
       noteLinkPlugin,

--- a/src/skrift-electron/renderer/components/NoteEditor/inputrules.ts
+++ b/src/skrift-electron/renderer/components/NoteEditor/inputrules.ts
@@ -12,6 +12,7 @@ import {
   makeInlineMathInputRule,
   REGEX_INLINE_MATH_DOLLARS, REGEX_BLOCK_MATH_DOLLARS
 } from "@benrbray/prosemirror-math";
+import { NodeSelection } from "prosemirror-state";
 
 export const buildInputRules = <S extends Schema>(schema: S) => {
   const hr = new InputRule(/^(---)$/, (state, match, start, end) => {

--- a/src/skrift-electron/renderer/components/NoteEditor/inputrules.ts
+++ b/src/skrift-electron/renderer/components/NoteEditor/inputrules.ts
@@ -1,4 +1,5 @@
 import { Schema } from "prosemirror-model";
+
 import {
   ellipsis,
   InputRule,
@@ -6,6 +7,11 @@ import {
   textblockTypeInputRule,
   wrappingInputRule,
 } from "prosemirror-inputrules";
+
+import {
+  makeBlockMathInputRule, makeInlineMathInputRule,
+  REGEX_INLINE_MATH_DOLLARS, REGEX_BLOCK_MATH_DOLLARS
+} from "@benrbray/prosemirror-math";
 
 export const buildInputRules = <S extends Schema>(schema: S) => {
   const hr = new InputRule(/^(---)$/, (state, match, start, end) => {
@@ -38,7 +44,10 @@ export const buildInputRules = <S extends Schema>(schema: S) => {
     (match) => ({ level: match[1].length })
   );
 
+  let inlineMathInputRule = makeInlineMathInputRule(REGEX_INLINE_MATH_DOLLARS, schema.nodes.math_inline);
+  let blockMathInputRule = makeBlockMathInputRule(REGEX_BLOCK_MATH_DOLLARS, schema.nodes.math_display);
+
   return inputRules({
-    rules: [ellipsis, hr, blockquote, orderedList, bulletList, heading],
+    rules: [ellipsis, hr, blockquote, orderedList, bulletList, heading, inlineMathInputRule, blockMathInputRule],
   });
 };

--- a/src/skrift-markdown/parser.test.ts
+++ b/src/skrift-markdown/parser.test.ts
@@ -25,4 +25,36 @@ describe("Parser", () => {
       ],
     });
   });
+
+  it("parses inline math", () => {
+    const markdown = "Here is some math: $1 + 2$";
+
+    const doc = markdownParser.parse(markdown);
+
+    expect(doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Here is some math: " },
+            { type: "math_inline" }
+          ]
+        }
+      ]
+    });
+  });
+
+  it("parses block math", () => {
+    const markdown = "$$\n1 + 2\n$$";
+
+    const doc = markdownParser.parse(markdown);
+
+    expect(doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        { type: "math_display" }
+      ]
+    });
+  });
 });

--- a/src/skrift-markdown/parser.test.ts
+++ b/src/skrift-markdown/parser.test.ts
@@ -38,7 +38,10 @@ describe("Parser", () => {
           type: "paragraph",
           content: [
             { type: "text", text: "Here is some math: " },
-            { type: "math_inline" }
+            {
+              type: "math_inline",
+              content: [{ type: "text", text: "1 + 2" }]
+            }
           ]
         }
       ]
@@ -53,7 +56,10 @@ describe("Parser", () => {
     expect(doc.toJSON()).toEqual({
       type: "doc",
       content: [
-        { type: "math_display" }
+        {
+          type: "math_display",
+          content: [{ type: "text", text: "1 + 2" }]
+        }
       ]
     });
   });

--- a/src/skrift-markdown/parser.ts
+++ b/src/skrift-markdown/parser.ts
@@ -2,40 +2,70 @@ import markdownit from "markdown-it";
 import { MarkdownParser, schema as markdownSchema } from "prosemirror-markdown";
 import { defaultMarkdownParser } from "prosemirror-markdown";
 import { Node, Schema } from "prosemirror-model";
+import markdownItMath from "markdown-it-math";
 
 export const schema = new Schema({
   // @ts-ignore
-  nodes: markdownSchema.spec.nodes.addBefore("text", "link", {
-    inline: true,
-    group: "inline",
-    content: "inline*",
-    atom: true,
-    draggable: false,
-    attrs: {
-      href: {},
-      title: { default: null },
-    },
-    inclusive: false,
-    parseDOM: [
-      {
-        tag: "a[href]",
-        // @ts-ignore
-        getAttrs(dom) {
-          return {
-            href: dom.getAttribute("href"),
-            title: dom.getAttribute("title"),
-          };
-        },
+  nodes: markdownSchema.spec.nodes.
+    addBefore("text", "link", {
+      inline: true,
+      group: "inline",
+      content: "inline*",
+      atom: true,
+      draggable: false,
+      attrs: {
+        href: {},
+        title: { default: null },
       },
-    ],
-    // @ts-ignore
-    toDOM(node: Node) {
-      return ["a", node.attrs, 0];
-    },
-  }),
+      inclusive: false,
+      parseDOM: [
+        {
+          tag: "a[href]",
+          // @ts-ignore
+          getAttrs(dom) {
+            return {
+              href: dom.getAttribute("href"),
+              title: dom.getAttribute("title"),
+            };
+          },
+        },
+      ],
+      // @ts-ignore
+      toDOM(node: Node) {
+        return ["a", node.attrs, 0];
+      },
+    }).
+    addBefore("text", "math_inline", {
+      group: "inline math",
+      content: "text*",
+      inline: true,
+      atom: true,
+      toDOM: () => ["math-inline", { class: "math-node" }, 0],
+      parseDOM: [{
+        tag: "math-inline"
+      }],
+    }).
+    addBefore("text", "math_display", {
+      group: "block math",
+      content: "text*",
+      atom: true,
+      code: true,
+      toDOM: () => ["math-display", { class: "math-node" }, 0],
+      parseDOM: [{
+        tag: "math-display"
+      }]
+    }),
   // @ts-ignore
   marks: markdownSchema.spec.marks.remove("link"),
 });
+
+const md = markdownit("commonmark", { html: false })
+  .use(markdownItMath, {
+    inlineOpen: '$',
+    inlineClose: '$',
+    blockOpen: '$$',
+    blockClose: '$$'
+  });
 
 const tokens = {
   ...defaultMarkdownParser.tokens,
@@ -47,11 +77,17 @@ const tokens = {
       title: tok.attrGet("title") || null,
     }),
   },
+  math_inline: {
+    node: "math_inline",
+  },
+  math_block: {
+    node: "math_display",
+  },
 };
 
 export const markdownParser = new MarkdownParser(
   schema,
   // @ts-ignore
-  markdownit("commonmark", { html: false }),
+  md,
   tokens
 );

--- a/src/skrift-markdown/serializer.test.ts
+++ b/src/skrift-markdown/serializer.test.ts
@@ -27,4 +27,42 @@ describe("Serializer", () => {
 
     expect(markdown).toEqual(`[ABC](https://abc.com)`);
   });
+
+  it("serializes inline math", () => {
+    const doc = Node.fromJSON(schema, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Here is math: " },
+            {
+              type: "math_inline",
+              content: [{ type: "text", text: "1 + 2" }]
+            }
+          ]
+        }
+      ]
+    });
+
+    const markdown = markdownSerializer.serialize(doc);
+
+    expect(markdown).toEqual("Here is math: $1 + 2$");
+  });
+
+  it("serializes block math", () => {
+    const doc = Node.fromJSON(schema, {
+      type: "doc",
+      content: [
+        {
+          type: "math_display",
+          content: [{ type: "text", text: "1 + 2" }]
+        }
+      ]
+    });
+
+    const markdown = markdownSerializer.serialize(doc);
+
+    expect(markdown).toEqual("$$\n1 + 2\n$$");
+  });
 });

--- a/src/skrift-markdown/serializer.ts
+++ b/src/skrift-markdown/serializer.ts
@@ -9,6 +9,16 @@ nodes.link = (state, node) => {
   state.renderInline(node);
   state.write(`](${node.attrs.href})`);
 };
+nodes.math_inline = (state, node) => {
+  state.write('$');
+  state.renderInline(node);
+  state.write('$');
+};
+nodes.math_display = (state, node) => {
+  state.write('$$\n');
+  state.renderInline(node);
+  state.write('\n$$');
+};
 const marks = defaultMarkdownSerializer.marks;
 
 export const markdownSerializer = new MarkdownSerializer(nodes, marks);

--- a/src/skrift-markdown/serializer.ts
+++ b/src/skrift-markdown/serializer.ts
@@ -18,6 +18,7 @@ nodes.math_display = (state, node) => {
   state.write('$$\n');
   state.renderInline(node);
   state.write('\n$$');
+  state.closeBlock(node);
 };
 const marks = defaultMarkdownSerializer.marks;
 

--- a/src/types/markdown-it-math.d.ts
+++ b/src/types/markdown-it-math.d.ts
@@ -1,0 +1,13 @@
+declare module 'markdown-it-math' {
+    import MarkdownIt from 'markdown-it';
+
+    interface MarkdownItMathOptions {
+        inlineOpen?: string;
+        inlineClose?: string;
+        blockOpen?: string;
+        blockClose?: string;
+    }
+
+    function markdownItMath(md: MarkdownIt, options?: MarkdownItMathOptions): void;
+    export default markdownItMath;
+} 


### PR DESCRIPTION
#6 

Todo:

- [x] Parse `$...$` and `$$...$$` in Markdown
- [ ] Backspace/delete should edit inline equation instead of removing it entirely
- [ ] Single `$$` should insert display math
- [ ] `AutoFocus` somehow clashes with `prosemirror-math` -- some error about auto flush in the console